### PR TITLE
Fixes: 1899 DAIHAN

### DIFF
--- a/games/1899 DAIHAN
+++ b/games/1899 DAIHAN
@@ -43,7 +43,7 @@ companies:
 
 revenue bonuses:
     label: 'Goods'
-    adds: [30, 40, 60, 80]
+    adds: [20, 30, 40, 60, 80]
 
 trains:
     name: '2'


### PR DESCRIPTION
Last weekend we played 1899 DAIHAN and it was great fun, your app came in super handy and really helped making the game flow better. Unfortunately, while playing I realized, that I made some errors when creating the 1899 DAIHAN file. This PR provides the fixes.

### Fixes
* `percent to float` is corrected to `0.5` instead of `0.6`
* Adds a **Goods** revenue bonus of `20`

**BGG:** [1899 DAIHAN](https://boardgamegeek.com/boardgame/428264/1899-daihan)
**Rules:** [English Rulebook](https://boardgamegeek.com/filepage/290153/1899-daihan-rulebook)